### PR TITLE
Scrum 35 back adicionar data final das tarefas

### DIFF
--- a/NINETECH/src/main/java/com/example/fatec/ninetech/controllers/TarefasController.java
+++ b/NINETECH/src/main/java/com/example/fatec/ninetech/controllers/TarefasController.java
@@ -385,6 +385,16 @@ public class TarefasController {
 				loggerProjeto.setProjeto(projeto1);
 				interfaceLoggerProjeto.save(loggerProjeto);
 
+				// Verifica se a nova data é maior que a data final do projeto
+				LocalDate dataTarefaAtualizada = tarefaAtualizada.getData();
+				LocalDate dataFinalProjeto = projeto1.getData_final();
+
+				if (dataTarefaAtualizada.isAfter(dataFinalProjeto)) {
+					// Atualizar a data_final do projeto com a data da tarefa atualizada
+					projeto1.setData_final(dataTarefaAtualizada);
+					interfaceProjeto.save(projeto1);
+				}
+
 				return new ResponseEntity<>(tarefaAtualizadaNoBanco, HttpStatus.OK);
 			} else {
 				return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/NINETECH/src/main/java/com/example/fatec/ninetech/controllers/TarefasController.java
+++ b/NINETECH/src/main/java/com/example/fatec/ninetech/controllers/TarefasController.java
@@ -195,6 +195,16 @@ public class TarefasController {
 			loggerProjeto.setProjeto(projeto1);
 			interfaceLoggerProjeto.save(loggerProjeto);
 
+			// Verifica se a data da nova tarefa é maior que a data_final do projeto
+			LocalDate dataTarefa = tarefas.getData();
+			LocalDate dataFinalProjeto = projeto1.getData_final();
+
+			if (dataTarefa.isAfter(dataFinalProjeto)) {
+				// Atualiza a data_final do projeto com a data da nova tarefa
+				projeto1.setData_final(dataTarefa);
+				interfaceProjeto.save(projeto1);
+			}
+
 			return new ResponseEntity<>(novaTarefa, HttpStatus.CREATED);
 		} catch (Exception e) {
 			return new ResponseEntity<>("Erro ao processar a requisição: " + e.getMessage(),


### PR DESCRIPTION
Adição de lógica para alterar a data final do projeto caso a data da tarefa > data final do projeto, tanto para uma nova tarefa, quanto para uma tarefa já existente. 